### PR TITLE
File: generate_tests.py

### DIFF
--- a/generate_tests.py
+++ b/generate_tests.py
@@ -47,8 +47,8 @@ def main():
         # do more later
     ]
 
-    widths = widths_to_test  # + weird_widths_to_test
-    depths = depths_to_test  # + weird_depths_to_test
+    widths = weird_widths_to_test + widths_to_test
+    depths = weird_depths_to_test + depths_to_test
 
     topdir = "./testing/tests"
     master = os.path.join(topdir, 'master')
@@ -99,8 +99,15 @@ def main():
                 print(stdout, flush=True)
                 if stderr is not None:
                     print(stderr, flush=True)
-                print("Calling genAlt({})".format(batchdir), flush=True)
-                genAlt(batchdir)
+
+                if not os.path.isfile(batchbit):
+                    print(
+                        "No bit file found: {}, skipping rest of generation..."
+                        .format(batchbit)
+                    )
+                else:
+                    print("Calling genAlt({})".format(batchdir), flush=True)
+                    genAlt(batchdir)
             else:
                 print(
                     '    Design {} already generated, skipping...'.

--- a/testing/gen.tcl
+++ b/testing/gen.tcl
@@ -13,6 +13,10 @@ set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
 # set_param tcl.collectionResultDisplayLimit 0
 set_property BITSTREAM.General.UnconstrainedPins {Allow} [current_design]
 
+foreach site [get_sites -of [get_tiles -filter {TYPE == BRAM_R}]] {
+  set_property PROHIBIT true $site
+}
+
 place_design
 route_design
 


### PR DESCRIPTION
- Made it so it checks for .bit file and prints error
  message if not found (meaning .bit file generation
  failed - presumably for not enough BRAM_L blocks.

File: testing/gen.tcl
- Mark all BRAM_R tile sites with PROHIBIT property.
  The reason is that prjxray doesn't handle BRAM_R's
  correctly yet.  See issue #1285.

Signed-off-by: Brent Nelson <nelson@ee.byu.edu>